### PR TITLE
Fix frontend proxy placement

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -35,7 +35,7 @@
       "last 1 chrome version",
       "last 1 firefox version",
       "last 1 safari version"
-    ],
-    "proxy": "http://3.99.219.3:5000"
-  }
+    ]
+  },
+  "proxy": "http://localhost:5001"
 }


### PR DESCRIPTION
- move `proxy` out of the `browserslist` block in `package.json`